### PR TITLE
fix: failing unit test on single digit days

### DIFF
--- a/lambdas/collect-findings/lambda.go
+++ b/lambdas/collect-findings/lambda.go
@@ -114,7 +114,7 @@ func (x *Lambda) resolveBucketKey(prefix string, report string) string {
 		prefix,
 		fmt.Sprintf("%d", int(t.Year())),
 		fmt.Sprintf("%02d", int(t.Month())),
-		fmt.Sprintf("%d", int(t.Day())),
+		fmt.Sprintf("%02d", t.Day()),
 		fmt.Sprintf("%d.json", t.Unix()),
 	)
 }


### PR DESCRIPTION
When for example it's the first of November like today. The object key was resolved to `<report>/2023/11/1/111111111.json` while the regex in the test expects a 2 digit day.