### PR TITLE
fix: remove page limit

### DIFF
--- a/lambdas/collect-findings/lambda.go
+++ b/lambdas/collect-findings/lambda.go
@@ -81,7 +81,7 @@ func (x *Lambda) downloadFindings(standard string) ([]byte, error) {
 
 	paginator := securityhub.NewGetFindingsPaginator(x.securityHubClient, x.getFindingsForStandard(standard))
 	pageNum := 0
-	for paginator.HasMorePages() && pageNum < 3 {
+	for paginator.HasMorePages() {
 		page, err := paginator.NextPage(x.ctx)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
In earlier testing I implemented a limit of max 3 pages. This does not make sense because this would limit us to a maximum of 300 findings. When you have more accounts you can easily get to this limit. Hence removing it.